### PR TITLE
feat:增加用于调试的镜像的Dockerfile,同时将镜像推送到dockerhub #9

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -98,6 +98,83 @@ dockers:
       - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
       - "--label=org.opencontainers.image.licenses=MIT"
 
+  - image_templates:
+      - "soulteary/webhook:linux-amd64-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-amd64-debug"
+    dockerfile: docker/Dockerfile.debug
+    use: buildx
+    goarch: amd64
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.source=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - image_templates:
+      - "soulteary/webhook:linux-arm64-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-arm64-debug"
+    dockerfile: docker/Dockerfile.debug
+    use: buildx
+    goos: linux
+    goarch: arm64
+    goarm: ''
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.source=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - image_templates:
+      - "soulteary/webhook:linux-armv7-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-armv7-debug"
+    dockerfile: docker/Dockerfile.debug
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "7"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm/v7"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.source=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+
+  - image_templates:
+      - "soulteary/webhook:linux-armv6-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-armv6-debug"
+    dockerfile: docker/Dockerfile.debug
+    use: buildx
+    goos: linux
+    goarch: arm
+    goarm: "6"
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm/v6"
+      - "--label=org.opencontainers.image.title={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.description={{ .ProjectName }}"
+      - "--label=org.opencontainers.image.url=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.source=https://github.com/soulteary/webhook"
+      - "--label=org.opencontainers.image.version={{ .Version }}"
+      - "--label=org.opencontainers.image.created={{ .Date }}"
+      - "--label=org.opencontainers.image.revision={{ .FullCommit }}"
+      - "--label=org.opencontainers.image.licenses=MIT"
 
 docker_manifests:
   - name_template: "soulteary/webhook:{{ .Tag }}"
@@ -106,6 +183,14 @@ docker_manifests:
       - "soulteary/webhook:linux-arm64-{{ .Tag }}"
       - "soulteary/webhook:linux-armv7-{{ .Tag }}"
       - "soulteary/webhook:linux-armv6-{{ .Tag }}"
+    skip_push: "false"
+  
+  - name_template: "soulteary/webhook:debug-{{ .Tag }}"
+    image_templates:
+      - "soulteary/webhook:linux-amd64-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-arm64-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-armv7-debug-{{ .Tag }}"
+      - "soulteary/webhook:linux-armv6-debug-{{ .Tag }}"
     skip_push: "false"
 
   - name_template: "soulteary/webhook:latest"

--- a/docker/Dockerfile.debug
+++ b/docker/Dockerfile.debug
@@ -1,0 +1,6 @@
+FROM alpine:3.19.0
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
+RUN apk --update add ca-certificates bash curl wget jq yq
+COPY webhook /usr/bin/webhook
+EXPOSE 8345/tcp
+ENTRYPOINT ["/usr/bin/webhook"]


### PR DESCRIPTION
解决[issue](https://github.com/soulteary/webhook/issues/9)
* 新增了一个Dockerfile.debug，用于构建测试调试使用的镜像
* [.goreleaser.yaml](https://github.com/soulteary/webhook/blob/main/.goreleaser.yaml)文件新增上传镜像到dockerhub的配置

ps: 镜像构建经过本地测试，上传dockerhub未测试，直接copy-paste